### PR TITLE
Use assert_equal and expect.to+eq to increment assertions counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,15 @@ Include BetterAssertDifference in your tests:
 
 ```ruby
   # For Rails
+  require 'better_assert_difference/rails_support'
   ActiveSupport::TestCase.include BetterAssertDifference
   # For MiniTest
+  require 'better_assert_difference/minitest_support'
   Minitest::Test.include BetterAssertDifference
   # For RSpec
+  require 'better_assert_difference/rspec_support'
   RSpec.configure do |config|
-    config.include AssertDifference
+    config.include BetterAssertDifference
   end
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
+require 'rspec/core/rake_task'
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -7,4 +8,8 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
 
-task :default => :test
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = Dir.glob('spec/**/*_spec.rb')
+end
+
+task default: [:test, :spec]

--- a/better_assert_difference.gemspec
+++ b/better_assert_difference.gemspec
@@ -21,9 +21,21 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.post_install_message = %q{
+    This new version requires an explicit `require` to be added to your test_helper.rb or spec_helper.rb
+
+    # For Rails
+    require 'better_assert_difference/rails_support'
+    # For MiniTest
+    require 'better_assert_difference/minitest_support'
+    # For RSpec
+    require 'better_assert_difference/rspec_support'
+  }
+
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'pry'
 end

--- a/lib/better_assert_difference/minitest_support.rb
+++ b/lib/better_assert_difference/minitest_support.rb
@@ -1,0 +1,19 @@
+module BetterAssertDifference
+  class MinitestSupport
+    class << self
+      def exception_kind
+        MiniTest::Assertion
+      end
+
+      def notify_failure(errors)
+        raise MiniTest::Assertion, errors.join("\n")
+      end
+
+      def assert_equal(context, computation, expectation)
+        context.assert_equal(expectation, computation)
+      end
+    end
+  end
+
+  TestFramework = MinitestSupport
+end

--- a/lib/better_assert_difference/rails_support.rb
+++ b/lib/better_assert_difference/rails_support.rb
@@ -1,5 +1,5 @@
 require_relative './minitest_support'
 
 module BetterAssertDifference
-  TestFramework = RailsSupport = MinitestSupport
+  RailsSupport = MinitestSupport # This will also set TestFramework to MinitestSupport
 end

--- a/lib/better_assert_difference/rails_support.rb
+++ b/lib/better_assert_difference/rails_support.rb
@@ -1,5 +1,5 @@
 require_relative './minitest_support'
 
 module BetterAssertDifference
-  TestFramework = MinitestSupport
+  TestFramework = RailsSupport = MinitestSupport
 end

--- a/lib/better_assert_difference/rails_support.rb
+++ b/lib/better_assert_difference/rails_support.rb
@@ -1,0 +1,5 @@
+require_relative './minitest_support'
+
+module BetterAssertDifference
+  TestFramework = MinitestSupport
+end

--- a/lib/better_assert_difference/rspec_support.rb
+++ b/lib/better_assert_difference/rspec_support.rb
@@ -1,0 +1,19 @@
+module BetterAssertDifference
+  class RspecSupport
+    class << self
+      def exception_kind
+        RSpec::Expectations::ExpectationNotMetError
+      end
+
+      def notify_failure(errors)
+        RSpec::Expectations.fail_with(errors.join("\n"))
+      end
+
+      def assert_equal(context, computation, expectation)
+        context.expect(computation).to context.eq(expectation)
+      end
+    end
+  end
+
+  TestFramework = RspecSupport
+end

--- a/lib/better_assert_difference/version.rb
+++ b/lib/better_assert_difference/version.rb
@@ -1,3 +1,3 @@
 module BetterAssertDifference
-  VERSION = '0.1.13'
+  VERSION = '0.2.0'
 end

--- a/spec/better_assert_difference_spec.rb
+++ b/spec/better_assert_difference_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+RSpec.describe BetterAssertDifference do
+  before(:each) do
+    @items = []
+  end
+
+  it 'test_multiple_expressions_success' do
+    assert_difference(['@items.count', -> { @items.count }]) { @items << 1 }
+  end
+
+  it 'test_multiple_expressions_success_with_diff' do
+    error_message = <<~FAILURE
+      2 assertions failed:
+      [0] Fruit didn't change by 3 {before: 0, after: 1}
+      [1] "@items.count" didn't change by 3 {before: 0, after: 0}
+    FAILURE
+    assert_failure_with_message(error_message) do
+      assert_difference([Fruit, '@items.count'], 3) { Fruit.create }
+    end
+  end
+
+  it 'test_implicit_count_on_active_record_class' do
+    assert_difference(Fruit, 1) { Fruit.create }
+  end
+
+  it 'test_implicit_count_on_active_record_relation' do
+    assert_difference(Fruit.all, 1) { Fruit.create }
+  end
+
+  it 'test_error_message_on_active_record_relation' do
+    error_message = <<~FAILURE
+      1 assertion failed:
+      Fruit didn't change by 3 {before: 0, after: 1}
+    FAILURE
+    assert_failure_with_message(error_message) do
+      assert_difference(Fruit, 3) { Fruit.create }
+    end
+  end
+
+  it 'test_single_expression_failure' do
+    error_message = <<~FAILURE
+      1 assertion failed:
+      \"@items.count\" didn't change by 1 {before: 0, after: 0}
+    FAILURE
+    assert_failure_with_message(error_message) do
+      assert_difference('@items.count') { }
+    end
+  end
+
+  it 'test_multiple_expressions_failure' do
+    error_message = <<~FAILURE
+      2 assertions failed:
+      [0] \"@items.count\" didn't change by 1 {before: 0, after: 0}
+      [1] \"@items.select(&:nil?).count\" didn't change by 1 {before: 0, after: 0}
+    FAILURE
+    assert_failure_with_message(error_message) do
+      assert_difference(['@items.count', '@items.select(&:nil?).count']) { }
+    end
+  end
+
+  it 'test_hash_expressions_success' do
+    assert_difference(-> { @items.count } => 1, '@items.count' => 1) { @items << 1 }
+  end
+
+  it 'test_hash_expressions_failure' do
+    error_message = <<~FAILURE
+      1 assertion failed:
+      \"@items.count\" didn't change by 3 {before: 0, after: 0}
+    FAILURE
+    assert_failure_with_message(error_message) do
+      assert_difference('@items.count' => 3) { }
+    end
+  end
+
+  it 'test_bad_difference_format' do
+    error_message = <<~FAILURE
+
+      Difference is a Fruit, it must be an integer.
+      If you want to assert the difference of multiple expressions wrap them in an array:
+      assert_difference [Foo, Bar], 1 { }
+
+    FAILURE
+    assert_failure_with_message(error_message, BetterAssertDifference::DifferenceException) do
+      assert_difference('@items.count', Fruit) { }
+    end
+  end
+
+  it 'test_bad_difference_format_as_hash' do
+    error_message = <<~FAILURE
+
+      Difference is a Fruit, it must be an integer.
+      If you want to assert the difference of multiple expressions wrap them in an array:
+      assert_difference [Foo, Bar], 1 { }
+
+    FAILURE
+    assert_failure_with_message(error_message, BetterAssertDifference::DifferenceException) do
+      assert_difference(Fruit => Fruit) { }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,27 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+require_relative '../test/active_record/base'
+require_relative '../test/dummy/fruit'
+require 'better_assert_difference'
+require 'better_assert_difference/rspec_support'
+require 'pry'
+require 'rspec'
+
+module BetterAssertDifference::TestHelpers
+  def assert_failure_with_message(expected_message, exception_class = RSpec::Expectations::ExpectationNotMetError)
+    begin
+      yield
+      fail "should fail with message : #{expected_message}"
+    rescue exception_class => exception
+      expect(expected_message[0..-2]).to eq(exception.message)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include BetterAssertDifference
+  config.include BetterAssertDifference::TestHelpers
+  config.after(:each) do
+    ActiveRecord::Base.reset_count
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'active_record/base'
 require 'dummy/fruit'
 require 'better_assert_difference'
+require 'better_assert_difference/minitest_support'
 require 'pry'
 require 'minitest/autorun'
 
@@ -21,4 +22,5 @@ module BetterAssertDifference::TestHelpers
   end
 end
 
+Minitest::Test.include(BetterAssertDifference)
 Minitest::Test.include(BetterAssertDifference::TestHelpers)


### PR DESCRIPTION
I've been frustrated by a test where `assert_difference` succeeded but the final report said `1 runs, 0 assertions, 0 failures, 0 errors, 0 skips`

The original `assert_difference` calls `assert_equal` which will in turn call `add_assertion` at some point, but we cannot do that here for two reasons:

1. We want to display all errors and `assert_equal` would raise its exception after the first failure
2. We seem to support RSpec, which uses `expects(...).to eq`

I did some change to handle assertions count while keeping the aforementioned reasons in mind.

This is a breaking change though (I added a post install message)

I also added tests to prove RSpec support.

`rake test` runs Minitest tests
`rake spec` runs RSpec tests
`rake` runs both

What do you think?